### PR TITLE
Potential fix for code scanning alert no. 8: Missing rate limiting

### DIFF
--- a/server/twilioMessagingOverrides.ts
+++ b/server/twilioMessagingOverrides.ts
@@ -1,4 +1,5 @@
 import type { Express, Request, Response, NextFunction } from "express";
+import rateLimit from "express-rate-limit";
 import { z } from "zod";
 import { storage } from "./storage";
 
@@ -132,8 +133,16 @@ function syncIntegrationStatuses() {
 export function registerTwilioMessagingOverrides(app: Express) {
   app.use(authMiddleware);
 
+  const pinLoginLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 5,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: "Too many PIN login attempts. Please try again later." },
+  });
+
   const pinLoginSchema = z.object({ pin: z.string().regex(/^\d{4}$/, "PIN must be exactly 4 digits") });
-  app.post("/api/auth/pin-login", (req, res) => {
+  app.post("/api/auth/pin-login", pinLoginLimiter, (req, res) => {
     const parsed = pinLoginSchema.safeParse(req.body);
     if (!parsed.success) return res.status(400).json({ error: "Invalid PIN" });
     const safeUser = storage.verifyPinLogin(parsed.data.pin);


### PR DESCRIPTION
Potential fix for [https://github.com/ammorg/AMM-APP/security/code-scanning/8](https://github.com/ammorg/AMM-APP/security/code-scanning/8)

Add an Express rate-limiting middleware and apply it specifically to the PIN login route before the handler. Best practice is to use `express-rate-limit` with a short window and low max attempts for login endpoints (for example, 5 attempts per 15 minutes per IP), returning a clear 429 response. This preserves existing functionality while preventing rapid repeated authorization attempts.

In `server/twilioMessagingOverrides.ts`:
- Add an import for `express-rate-limit`.
- Define a `pinLoginLimiter` near route setup (inside `registerTwilioMessagingOverrides` is fine).
- Update `app.post("/api/auth/pin-login", ...)` to include `pinLoginLimiter` as middleware before the handler.

No business logic changes are needed beyond middleware insertion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
